### PR TITLE
Add bert score metric

### DIFF
--- a/compute_all_metric.py
+++ b/compute_all_metric.py
@@ -5,6 +5,11 @@ import os
 
 from utils.utils import prepare_json, get_metric
 
+ACCEPTED_METRIC_TYPES = [
+    "clip-score", "pac-score", "pac-score++",
+    "polos", "standard", "bert-score", "bert-score++"
+]
+
 if __name__ == '__main__':
     # Argument parsing
     parser = argparse.ArgumentParser(description='Evaluation')

--- a/metrics/bert_score.py
+++ b/metrics/bert_score.py
@@ -93,7 +93,7 @@ class BertScoreImproved(BaseMetric):
 
         bert_scores = list()
         scores = dict()
-        for refs, cand in zip(gts_cs[:10], gen_cs[:10]):
+        for refs, cand in zip(gts_cs, gen_cs):
             ensembled_ref_matrix = self.get_ensemble_reference_word_vectors(
                 refs, idf_dict, all_layers=False, default_threshold=0.83
             )

--- a/metrics/bert_score.py
+++ b/metrics/bert_score.py
@@ -1,0 +1,47 @@
+
+import torch
+import numpy as np
+from .base_metric import BaseMetric
+
+from bert_score import score
+
+class BertScoreBasic(BaseMetric):
+
+    def __init__(self, lang="en"):
+        self.lang = lang
+
+    def setup(self, use_tfidf=False):
+        self.use_tfidf = use_tfidf
+        # if not using tfidf, all words/tokens will be treated with same weight
+        # if use tfidf, the weight will be retrieved from reference captions
+
+    def compute_score(self, ims_cs, gen_cs, gts_cs=None, gts=None, gen=None):
+        """
+            please refer to this `score` method from the original author
+            https://github.com/Tiiiger/bert_score/blob/master/bert_score/score.py
+            the length of the `gts` and
+        :param ims_cs: List<String>, each string is a path to the image
+        :param gen_cs: List<List<String>>, tokenized each candidate captions
+        :param gts_cs: tokenized each reference captions
+        :param gts: List<String>/List<List<String>>, list ground truth (reference) captions
+        :param gen: List<String>, list candidate captions
+        :return:
+        """
+        P_bert, R_bert, F_bert = score(
+            cands=gen,
+            refs=gts,
+            lang=self.lang,
+            idf=self.use_tfidf
+        )
+        return np.mean(F_bert)
+
+class BertScoreImproved(BaseMetric):
+
+    def __init__(self, lang="en"):
+        self.lang = lang
+
+    def setup(self):
+        pass # doing nothing at the moment
+
+    def compute_score(self, ims_cs, gen_cs, gts_cs=None, gts=None, gen=None):
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ antlr4-python3-runtime==4.8
 appdirs==1.4.4
 async-timeout==4.0.3
 attrs==23.2.0
+bert-score==0.3.13
 bitarray==2.9.2
 braceexpand==0.1.7
 Brotli @ file:///croot/brotli-split_1714483155106/work

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,7 +5,7 @@ import os
 from metrics.clip_score import ClipScoreMetric
 from metrics.polos import PolosMetric
 from metrics.standard import StandardMetric
-
+from metrics.bert_score import BertScoreBasic, BertScoreImproved
 
 def collate_fn(batch):
     if isinstance(batch, tuple) and isinstance(batch[0], list):
@@ -67,5 +67,9 @@ def get_metric(name, **kwargs):
         return PolosMetric(device=kwargs.get("device"))
     elif name == "standard":
         return StandardMetric()
+    elif name == "bert-score":
+        return BertScoreBasic("en")
+    elif name == "bert-score++":
+        return BertScoreImproved("en")
     else:
         raise ValueError(f"Unknown metric: {name}")


### PR DESCRIPTION
I added 2 classes BertScoreBasic and BertScoreImproved which compute the Bert-score and Bert Score Improved respectively.

the `BertScoreBasic` is kinda straight forward since most of the code was implemented by Bert-score author already. You can double check with its codebase [here](https://github.com/Tiiiger/bert_score)

the `BertScoreImproved ` is a little more tricky to implement because it requires an extra step creating a combined embedded token captions with a threshold 0.83 as recommended in the [paper](https://aclanthology.org/2020.acl-main.93/) for RoBERTa (large), then performing the matrix search like the Basic bert-score to find the Precision, Recall. Please note that this class currently does not replicate completely the Bert-score++ metric as the original paper it still to be modified to use the idf weight to $R_{rm}$ part of the Bert-score++ paper (mentioned in the section [3.5 Summaryandmetric formula](https://aclanthology.org/2020.acl-main.93/))