### PR TITLE
add UMIC metric to the benchmark

### DIFF
--- a/compute_all_metric.py
+++ b/compute_all_metric.py
@@ -7,7 +7,8 @@ from utils.utils import prepare_json, get_metric
 
 ACCEPTED_METRIC_TYPES = [
     "clip-score", "pac-score", "pac-score++",
-    "polos", "standard", "bert-score", "bert-score++"
+    "polos", "standard", "bert-score", "bert-score++",
+    "umic-score"
 ]
 
 if __name__ == '__main__':

--- a/config/Base-RCNN-FPN.yaml
+++ b/config/Base-RCNN-FPN.yaml
@@ -1,0 +1,42 @@
+MODEL:
+  META_ARCHITECTURE: "GeneralizedRCNN"
+  BACKBONE:
+    NAME: "build_resnet_fpn_backbone"
+  RESNETS:
+    OUT_FEATURES: ["res2", "res3", "res4", "res5"]
+  FPN:
+    IN_FEATURES: ["res2", "res3", "res4", "res5"]
+  ANCHOR_GENERATOR:
+    SIZES: [[32], [64], [128], [256], [512]]  # One size for each in feature map
+    ASPECT_RATIOS: [[0.5, 1.0, 2.0]]  # Three aspect ratios (same for all in feature maps)
+  RPN:
+    IN_FEATURES: ["p2", "p3", "p4", "p5", "p6"]
+    PRE_NMS_TOPK_TRAIN: 2000  # Per FPN level
+    PRE_NMS_TOPK_TEST: 1000  # Per FPN level
+    # Detectron1 uses 2000 proposals per-batch,
+    # (See "modeling/rpn/rpn_outputs.py" for details of this legacy issue)
+    # which is approximately 1000 proposals per-image since the default batch size for FPN is 2.
+    POST_NMS_TOPK_TRAIN: 1000
+    POST_NMS_TOPK_TEST: 1000
+  ROI_HEADS:
+    NAME: "StandardROIHeads"
+    IN_FEATURES: ["p2", "p3", "p4", "p5"]
+  ROI_BOX_HEAD:
+    NAME: "FastRCNNConvFCHead"
+    NUM_FC: 2
+    POOLER_RESOLUTION: 7
+  ROI_MASK_HEAD:
+    NAME: "MaskRCNNConvUpsampleHead"
+    NUM_CONV: 4
+    POOLER_RESOLUTION: 14
+DATASETS:
+  TRAIN: ("coco_2017_train",)
+  TEST: ("coco_2017_val",)
+SOLVER:
+  IMS_PER_BATCH: 16
+  BASE_LR: 0.02
+  STEPS: (60000, 80000)
+  MAX_ITER: 90000
+INPUT:
+  MIN_SIZE_TRAIN: (640, 672, 704, 736, 768, 800)
+VERSION: 2

--- a/config/COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml
+++ b/config/COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml
@@ -1,0 +1,9 @@
+_BASE_: "../Base-RCNN-FPN.yaml"
+MODEL:
+  WEIGHTS: "detectron2://ImageNetPretrained/MSRA/R-101.pkl"
+  MASK_ON: False
+  RESNETS:
+    DEPTH: 101
+SOLVER:
+  STEPS: (210000, 250000)
+  MAX_ITER: 270000

--- a/config/model_paths.json
+++ b/config/model_paths.json
@@ -1,4 +1,5 @@
 {
   "pac-score_ViT-B/32": "checkpoints/clip_ViT-B-32.pth",
-  "pac-score++_ViT-B/32": "checkpoints/PAC++_clip_ViT-B-32.pth"
+  "pac-score++_ViT-B/32": "checkpoints/PAC++_clip_ViT-B-32.pth",
+  "umic": "checkpoints/umic.pt"
 }

--- a/config/uniter-config/uniter-base.json
+++ b/config/uniter-config/uniter-base.json
@@ -1,0 +1,13 @@
+{
+  "attention_probs_dropout_prob": 0.1,
+  "hidden_act": "gelu",
+  "hidden_dropout_prob": 0.1,
+  "hidden_size": 768,
+  "initializer_range": 0.02,
+  "intermediate_size": 3072,
+  "max_position_embeddings": 512,
+  "num_attention_heads": 12,
+  "num_hidden_layers": 12,
+  "type_vocab_size": 2,
+  "vocab_size": 28996
+}

--- a/metrics/umic_score.py
+++ b/metrics/umic_score.py
@@ -1,0 +1,87 @@
+import torch
+import numpy as np
+from .base_metric import BaseMetric
+
+from detectron2.engine import DefaultPredictor
+from detectron2.config import get_cfg
+from detectron2.data import transforms as T
+from detectron2 import model_zoo
+
+from PIL import Image
+
+class UmicScore(BaseMetric):
+    """
+    This class reproduce the UMIC score which can be applied for ANY new dataset.
+    That is the major difference from this class to the [UMIC](https://github.com/hwanheelee1993/UMIC).
+    The original work already pre-embedded images of the common datasets like: COMPOSITE, FLICKR, etc.
+    Because this class serve a more generic purpose so it would take longer time to run since
+    it requires detectron2 to detect the bounding boxes and its corresponding feature vectors
+    in any images (please view the UNITER model on how to use detectron2)
+    """
+
+    def __init__(self):
+        pass
+    def setup(self):
+        # this class heavily depend on detectron2, is used to embed the input images
+        self.imageEmbedder = ImageFeatureEmbedder()
+
+    def load_model(self):
+        pass
+
+    def compute_score(
+            self,
+            ims_cs,
+            gen_cs,
+            gts_cs,
+            gts,
+            gen
+        ):
+        """
+        :param ims_cs: Required List<String>, list of path to the image
+        :param gen_cs: Required List<String>, list candidate caption
+        :param gts_cs: Nullable
+        :param gts: Nullable
+        :param gen: Nullable
+        :return: Float, the UMIC score
+        """
+
+        assert len(ims_cs) == len(gen_cs), "list of ims_cs and gen_cs are expected to be the same"
+
+        for img_path, cand_cap in zip(ims_cs, gen_cs):
+            image = self.read_image(img_path)
+        return {"umic-score": 0}
+
+    def read_image(self, image_path):
+        image = Image.open(image_path)
+        return np.array(image)
+
+class ImageFeatureEmbedder:
+    """
+    This class is used to generate the image features and object boxes from image,
+    which result would be served as input for UNITER model (with UMIC weight)
+    """
+    def __init__(self):
+        """
+        For the constructor to run properly please find download the
+        `faster_rcnn_R_101_FPN_3x.yaml` and `Base-RCNN-FPN.yaml` in the correct directory.
+        You can find the original source of these 2 yaml files in detectron2 repository
+        https://github.com/facebookresearch/detectron2/tree/main/configs
+        """
+        self.cfg = get_cfg()
+        self.cfg.merge_from_file("config/COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml")
+        self.cfg.MODEL.WEIGHTS = model_zoo.get_checkpoint_url("COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x.yaml")
+        self.cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.2
+
+        self.aug = T.ResizeShortestEdge(
+            [self.cfg.INPUT.MIN_SIZE_TEST, self.cfg.INPUT.MIN_SIZE_TEST],
+            self.cfg.INPUT.MAX_SIZE_TEST
+        )
+        pass
+
+    def embed_image(self, image_array):
+        """
+
+        :param image_array: shape of (Height, Width, channel)
+        :return: a tuple of (array shape of [1, N, 2048], array shape of (1, N, 7))
+        """
+        pass

--- a/metrics/umic_score.py
+++ b/metrics/umic_score.py
@@ -1,5 +1,7 @@
 import torch
 import numpy as np
+from torch import device
+
 from .base_metric import BaseMetric
 
 from detectron2.engine import DefaultPredictor
@@ -7,7 +9,14 @@ from detectron2.config import get_cfg
 from detectron2.data import transforms as T
 from detectron2 import model_zoo
 
+from transformers import BertTokenizer
+
+from models.uniter.model import UniterModel
+from utils.config import load_model_paths
+
 from PIL import Image
+
+import math
 
 class UmicScore(BaseMetric):
     """
@@ -19,14 +28,36 @@ class UmicScore(BaseMetric):
     in any images (please view the UNITER model on how to use detectron2)
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, rcnn_file="faster_rcnn_R_101_FPN_3x.yaml"):
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.rcnn_file = rcnn_file
+        self.IMAGE_DIM = 1024 if self.rcnn_file == "faster_rcnn_R_101_FPN_3x.yaml" else 2048
+
+        
     def setup(self):
         # this class heavily depend on detectron2, is used to embed the input images
-        self.imageEmbedder = ImageFeatureEmbedder()
+        self.load_model()
 
     def load_model(self):
-        pass
+        self.imageEmbedder = ImageFeatureEmbedder(self.device, self.rcnn_file)
+        self.candidateTextEmbedder = CandidateCaptionEmbedder(self.device)
+
+        # You need to have `umic.pt` file in checkpoints folder
+        # `umic.pt` can be download from here https://archive.org/download/umic_data/umic.pt sourced in
+        # the author of UMIC metric repository
+        # https://github.com/hwanheelee1993/UMIC?tab=readme-ov-file#-2-download-the-pretrained-model-
+        umic_state = torch.load(load_model_paths()["umic"])
+        self.umicModel = UniterModel.from_pretrained(
+            config_file="config/uniter-config/uniter-base.json",
+            state_dict=umic_state,
+            img_dim=self.IMAGE_DIM
+        )
+        self.umicModel.to(self.device).eval()
+
+        self.rank_output = torch.nn.Linear(self.umicModel.config.hidden_size, 1).cuda()
+        self.pooler = self.umicModel.pooler
+
+        # pass
 
     def compute_score(
             self,
@@ -47,9 +78,45 @@ class UmicScore(BaseMetric):
 
         assert len(ims_cs) == len(gen_cs), "list of ims_cs and gen_cs are expected to be the same"
 
+        rank_scores = list()
+
         for img_path, cand_cap in zip(ims_cs, gen_cs):
             image = self.read_image(img_path)
-        return {"umic-score": 0}
+            img_feat, img_box = self.imageEmbedder.embed_image(image)
+            img_mask = torch.ones(1, img_feat.shape[1], dtype=torch.long).to(self.device)
+
+            cand_input_ids, cand_input_masks = self.candidateTextEmbedder.tokenize(cand_cap)
+
+            # size of joint_mask is: N + L + 2
+            # plus 2 tokens because the CLS (id=101) and SEP (id=102)
+            # L is the number of token of cand_cap, or number of tokens of the longest caption in a batch
+            joint_mask = torch.cat([img_mask, cand_input_masks], dim=1).to(self.device)
+            position_ids = torch.arange(cand_input_ids.shape[1], dtype=torch.long, device=self.device)
+            gather_ids = torch\
+                .arange(cand_input_ids.shape[1] + img_feat.shape[1], dtype=torch.long, device=self.device)\
+                .unsqueeze(0)
+
+            outputs = self.umicModel(
+                input_ids=cand_input_ids,
+                attention_mask=joint_mask,
+                position_ids=position_ids,
+                img_feat=img_feat,
+                img_pos_feat=img_box,
+                gather_index=gather_ids,
+                output_all_encoded_layers=False
+            )
+
+
+            pooled_output = self.pooler(outputs)
+            scores = self.rank_output(pooled_output)
+            rank_scores += [scores.squeeze().detach().cpu().numpy()]
+
+        # this step is refer to UMIC repository
+        umic_score = [1/(1+math.exp(-rank_score)) for rank_score in rank_scores] # sigmoid
+
+
+            # print(img_feat.shape, img_box.shape, cand_input_ids.size(1), position_ids)
+        return {"umic-score": sum(umic_score)/ len(umic_score)}
 
     def read_image(self, image_path):
         image = Image.open(image_path)
@@ -57,31 +124,134 @@ class UmicScore(BaseMetric):
 
 class ImageFeatureEmbedder:
     """
-    This class is used to generate the image features and object boxes from image,
-    which result would be served as input for UNITER model (with UMIC weight)
+    Generate image region features + object boxes in UNITER format.
+    Outputs:
+        img_feat: (1, N, 2048)
+        img_pos:  (1, N, 7)
     """
-    def __init__(self):
-        """
-        For the constructor to run properly please find download the
-        `faster_rcnn_R_101_FPN_3x.yaml` and `Base-RCNN-FPN.yaml` in the correct directory.
-        You can find the original source of these 2 yaml files in detectron2 repository
-        https://github.com/facebookresearch/detectron2/tree/main/configs
-        """
-        self.cfg = get_cfg()
-        self.cfg.merge_from_file("config/COCO-Detection/faster_rcnn_R_101_FPN_3x.yaml")
-        self.cfg.MODEL.WEIGHTS = model_zoo.get_checkpoint_url("COCO-InstanceSegmentation/mask_rcnn_R_101_C4_3x.yaml")
-        self.cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.2
+    def __init__(self, device="cuda", file="faster_rcnn_R_101_C4_3x.yaml"):
+        self.device = device
 
+        # Load Faster R-CNN R101 FPN config
+        self.cfg = get_cfg()
+        self.cfg.merge_from_file(f"config/COCO-Detection/{file}")
+        self.cfg.MODEL.WEIGHTS = model_zoo.get_checkpoint_url(
+            f"COCO-Detection/{file}"
+        )
+        self.cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.2
+        self.cfg.MODEL.DEVICE = device
+
+        # Preprocessing augmentation
         self.aug = T.ResizeShortestEdge(
             [self.cfg.INPUT.MIN_SIZE_TEST, self.cfg.INPUT.MIN_SIZE_TEST],
             self.cfg.INPUT.MAX_SIZE_TEST
         )
-        pass
 
-    def embed_image(self, image_array):
+        # Build predictor and raw model
+        self.predictor = DefaultPredictor(self.cfg)
+        self.model = self.predictor.model.eval()
+
+    def _boxes_to_uniter_7d(self, boxes, img_h, img_w):
+        """
+        Convert (N,4) → (N,7): [x1, y1, x2, y2, area, W, H]
+        """
+        x1, y1, x2, y2 = (
+            boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+        )
+        area = (x2 - x1) * (y2 - y1)
+
+        pos = np.stack([
+            x1, y1, x2, y2,
+            area,
+            np.full_like(area, img_w),
+            np.full_like(area, img_h)
+        ], axis=1)
+
+        return pos  # (N, 7)
+
+    def embed_image(self, img):
+        """
+        :param pil_image: PIL.Image instance, RGB
+        :return: (1, N, 2048) features, (1, N, 7) positional features
         """
 
-        :param image_array: shape of (Height, Width, channel)
-        :return: a tuple of (array shape of [1, N, 2048], array shape of (1, N, 7))
-        """
-        pass
+        img_h, img_w = img.shape[:2]
+
+        # detectron2 expects BGR channel order
+        img_bgr = img[:, :, ::-1]
+
+        # apply resizing augmentation
+        transform = self.aug.get_transform(img_bgr)
+        img_trans = transform.apply_image(img_bgr)
+
+        # convert to CHW tensor
+        img_tensor = torch.as_tensor(
+            img_trans.astype("float32").transpose(2, 0, 1)
+        )
+
+        inputs = [{
+            "image": img_tensor.to(self.device),
+            "height": img_h,
+            "width": img_w
+        }]
+
+        # Extract FPN region features
+        with torch.no_grad():
+            images = self.model.preprocess_image(inputs)
+            features = self.model.backbone(images.tensor)
+
+            # Proposals
+            proposals, _ = self.model.proposal_generator(images, features, None)
+
+            # RoIAlign pooled features
+            box_features = self.model.roi_heads.box_pooler(
+                [features[f] for f in self.model.roi_heads.in_features],
+                [p.proposal_boxes for p in proposals]
+            )
+
+            # Final FC box head (gives 2048-D vectors)
+            box_features = self.model.roi_heads.box_head(box_features)
+            region_features = box_features.cpu().numpy()  # (N, 2048)
+
+        # --- Step 5: bounding boxes ---
+        boxes = proposals[0].proposal_boxes.tensor.cpu().numpy()  # (N, 4)
+
+        # --- Step 6: convert boxes → 7D ---
+        pos_7d = self._boxes_to_uniter_7d(boxes, img_h, img_w)  # (N, 7)
+
+        # --- Step 7: add batch dimension ---
+        img_feat = region_features[None, :, :]   # (1, N, 1024)
+        img_pos  = pos_7d[None, :, :]            # (1, N, 7)
+
+        assert img_feat.shape[2] == 1024, "dimension of image feature is not 1024"
+        assert img_pos.shape[2] == 7, "dimension of image box is not 7"
+        assert img_feat.shape[1] == img_pos.shape[1], "N is not equal for img_feat and img_pos"
+
+        return (torch.from_numpy(img_feat).to(self.device),
+                torch.from_numpy(img_pos).to(self.device))
+
+class CandidateCaptionEmbedder:
+    def __init__(self, device="cuda"):
+        self.device = device
+        self.tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-uncased")
+
+    def tokenize(self, cand_caption):
+
+        tokens = self.tokenizer(
+            cand_caption,
+            return_tensors="pt",
+            padding=True,
+            truncation=True
+        )
+        # input_ids = []
+        # for word in cand_caption.split():
+        #     ws = self.tokenizer.tokenize(word)
+        #     if not ws:
+        #         # some special char
+        #         continue
+        #     input_ids.extend(self.tokenizer.convert_tokens_to_ids(ws))
+        # input_ids = torch.from_numpy(np.array(input_ids)).unsqueeze(0)
+        # mask = torch.ones(input_ids.shape, dtype=torch.long)
+
+        return tokens["input_ids"].to(self.device), tokens["attention_mask"].to(self.device)
+        # return input_ids.to(self.device), mask.to(self.device)

--- a/metrics/umic_score.py
+++ b/metrics/umic_score.py
@@ -1,14 +1,20 @@
+from detectron2.engine import DefaultPredictor
+from detectron2.config import get_cfg
+from detectron2.data import transforms as T
+from detectron2 import model_zoo
+"""
+    HOW TO INSTALL Detectron2? if you cannot install with the standard method like this
+    [instruction](https://detectron2.readthedocs.io/en/latest/tutorials/install.html)
+    please review this
+    [discussion](https://github.com/facebookresearch/detectron2/discussions/5200).
+    this is how I installed Detectron2
+    pip install --extra-index-url https://miropsota.github.io/torch_packages_builder detectron2==0.6+18f6958pt2.8.0cu129
+"""
 import torch
 import numpy as np
 from torch import device
 
 from .base_metric import BaseMetric
-
-from detectron2.engine import DefaultPredictor
-from detectron2.config import get_cfg
-from detectron2.data import transforms as T
-from detectron2 import model_zoo
-
 from transformers import BertTokenizer
 
 from models.uniter.model import UniterModel
@@ -24,11 +30,14 @@ class UmicScore(BaseMetric):
     That is the major difference from this class to the [UMIC](https://github.com/hwanheelee1993/UMIC).
     The original work already pre-embedded images of the common datasets like: COMPOSITE, FLICKR, etc.
     Because this class serve a more generic purpose so it would take longer time to run since
-    it requires detectron2 to detect the bounding boxes and its corresponding feature vectors
+    it requires Detectron2 to detect the bounding boxes and its corresponding feature vectors
     in any images (please view the UNITER model on how to use detectron2)
     """
 
     def __init__(self, rcnn_file="faster_rcnn_R_101_FPN_3x.yaml"):
+        """
+        :param rcnn_file: name of yaml file to configure detectron2
+        """
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.rcnn_file = rcnn_file
         self.IMAGE_DIM = 1024 if self.rcnn_file == "faster_rcnn_R_101_FPN_3x.yaml" else 2048
@@ -57,7 +66,6 @@ class UmicScore(BaseMetric):
         self.rank_output = torch.nn.Linear(self.umicModel.config.hidden_size, 1).cuda()
         self.pooler = self.umicModel.pooler
 
-        # pass
 
     def compute_score(
             self,
@@ -81,6 +89,8 @@ class UmicScore(BaseMetric):
         rank_scores = list()
 
         for img_path, cand_cap in zip(ims_cs, gen_cs):
+            # TODO: This version is currently calculate UMIC score for 1-by-1 image, next task is to
+            #  use dataloader to process data in batch.
             image = self.read_image(img_path)
             img_feat, img_box = self.imageEmbedder.embed_image(image)
             img_mask = torch.ones(1, img_feat.shape[1], dtype=torch.long).to(self.device)
@@ -114,8 +124,6 @@ class UmicScore(BaseMetric):
         # this step is refer to UMIC repository
         umic_score = [1/(1+math.exp(-rank_score)) for rank_score in rank_scores] # sigmoid
 
-
-            # print(img_feat.shape, img_box.shape, cand_input_ids.size(1), position_ids)
         return {"umic-score": sum(umic_score)/ len(umic_score)}
 
     def read_image(self, image_path):
@@ -129,7 +137,18 @@ class ImageFeatureEmbedder:
         img_feat: (1, N, 2048)
         img_pos:  (1, N, 7)
     """
-    def __init__(self, device="cuda", file="faster_rcnn_R_101_C4_3x.yaml"):
+    def __init__(self, device="cuda", file="faster_rcnn_R_101_FPN_3x.yaml"):
+        """
+        :param device: suggest to have cuda environment to load detectron model
+        :param file: name of the detectron config file, if you use other configurations, make sure to place it in
+            config/COCO-Detection folder and its base config in config/ folder. For example, I put
+            `faster_rcnn_R_101_FPN_3x.yaml` in config/COCO-Detection/ and `Base-RCNN-FPN.yaml` in config/
+            You can download other config from https://github.com/facebookresearch/detectron2/tree/main/configs.
+            However, please adjust `UmicScore.IMAGE_DIM` and potentially make change to ImageFeatureEmbedder.embed_image
+            corresponding to the dimension output of your configuration selection. The UMIC author seems to use
+            `faster_rcnn_R_101_C4_3x.yaml` producing 2048 IMAGE_DIM but in this repository I chose
+            `faster_rcnn_R_101_FPN_3x.yaml` producing 1024 IMAGE DIM
+        """
         self.device = device
 
         # Load Faster R-CNN R101 FPN config
@@ -153,7 +172,8 @@ class ImageFeatureEmbedder:
 
     def _boxes_to_uniter_7d(self, boxes, img_h, img_w):
         """
-        Convert (N,4) → (N,7): [x1, y1, x2, y2, area, W, H]
+        Convert (N,4) → (N,7): [x1, y1, x2, y2, W, H, area]
+        reference from UNITER model paper https://arxiv.org/pdf/1909.11740
         """
         x1, y1, x2, y2 = (
             boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
@@ -162,9 +182,9 @@ class ImageFeatureEmbedder:
 
         pos = np.stack([
             x1, y1, x2, y2,
-            area,
             np.full_like(area, img_w),
-            np.full_like(area, img_h)
+            np.full_like(area, img_h),
+            area
         ], axis=1)
 
         return pos  # (N, 7)
@@ -172,7 +192,7 @@ class ImageFeatureEmbedder:
     def embed_image(self, img):
         """
         :param pil_image: PIL.Image instance, RGB
-        :return: (1, N, 2048) features, (1, N, 7) positional features
+        :return: a tuple of 2: (1, N, 2048) features, (1, N, 7) positional features. Normally, N is 1000
         """
 
         img_h, img_w = img.shape[:2]
@@ -223,7 +243,7 @@ class ImageFeatureEmbedder:
         img_feat = region_features[None, :, :]   # (1, N, 1024)
         img_pos  = pos_7d[None, :, :]            # (1, N, 7)
 
-        assert img_feat.shape[2] == 1024, "dimension of image feature is not 1024"
+        # assert img_feat.shape[2] == 1024, "dimension of image feature is not 1024"
         assert img_pos.shape[2] == 7, "dimension of image box is not 7"
         assert img_feat.shape[1] == img_pos.shape[1], "N is not equal for img_feat and img_pos"
 
@@ -232,10 +252,24 @@ class ImageFeatureEmbedder:
 
 class CandidateCaptionEmbedder:
     def __init__(self, device="cuda"):
+        """
+        This class is a rework from UMIC repository, please check their original work in
+        https://github.com/hwanheelee1993/UMIC/blob/master/make_txt_db.py
+        :param device:
+        """
         self.device = device
         self.tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-uncased")
 
     def tokenize(self, cand_caption):
+        """
+        This function is basically just to "map" each token/word into a single number.
+        The original work of UMIC author was to do it manually which does not include the [CLS]-101
+        and [SEP]-102 token. Original version is
+        https://github.com/hwanheelee1993/UMIC/blob/9d897ee575d754dada84e00da426bbceabffc450/make_txt_db.py#L18
+        The only difference is my work has CLS at beginning and SEP at the end of each sequence
+        :param cand_caption:
+        :return:
+        """
 
         tokens = self.tokenizer(
             cand_caption,

--- a/models/uniter/layer.py
+++ b/models/uniter/layer.py
@@ -1,0 +1,233 @@
+"""
+BERT layers from the huggingface implementation
+(https://github.com/huggingface/transformers)
+"""
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors and The HuggingFace Inc. team.
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import math
+
+import torch
+from torch import nn
+from torch.nn import LayerNorm as BertLayerNorm
+
+
+logger = logging.getLogger(__name__)
+
+
+def gelu(x):
+    """Implementation of the gelu activation function.
+        For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
+        0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
+        Also see https://arxiv.org/abs/1606.08415
+    """
+    return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
+
+
+def swish(x):
+    return x * torch.sigmoid(x)
+
+
+ACT2FN = {"gelu": gelu, "relu": torch.nn.functional.relu, "swish": swish}
+
+
+class GELU(nn.Module):
+    def forward(self, input_):
+        output = gelu(input_)
+        return output
+
+
+class BertSelfAttention(nn.Module):
+    def __init__(self, config):
+        super(BertSelfAttention, self).__init__()
+        if config.hidden_size % config.num_attention_heads != 0:
+            raise ValueError(
+                "The hidden size (%d) is not a multiple of the number of attention "
+                "heads (%d)" % (config.hidden_size, config.num_attention_heads))
+        self.num_attention_heads = config.num_attention_heads
+        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(config.hidden_size, self.all_head_size)
+        self.key = nn.Linear(config.hidden_size, self.all_head_size)
+        self.value = nn.Linear(config.hidden_size, self.all_head_size)
+
+        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
+
+    def transpose_for_scores(self, x):
+        new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
+        x = x.view(*new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(self, hidden_states, attention_mask):
+        mixed_query_layer = self.query(hidden_states)
+        mixed_key_layer = self.key(hidden_states)
+        mixed_value_layer = self.value(hidden_states)
+
+        query_layer = self.transpose_for_scores(mixed_query_layer)
+        key_layer = self.transpose_for_scores(mixed_key_layer)
+        value_layer = self.transpose_for_scores(mixed_value_layer)
+
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        # Apply the attention mask is (precomputed for all layers in BertModel forward() function)
+        attention_scores = attention_scores + attention_mask
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.Softmax(dim=-1)(attention_scores)
+
+        # This is actually dropping out entire tokens to attend to, which might
+        # seem a bit unusual, but is taken from the original Transformer paper.
+        attention_probs = self.dropout(attention_probs)
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(*new_context_layer_shape)
+        return context_layer
+
+
+class BertSelfOutput(nn.Module):
+    def __init__(self, config):
+        super(BertSelfOutput, self).__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.LayerNorm = BertLayerNorm(config.hidden_size, eps=1e-12)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertAttention(nn.Module):
+    def __init__(self, config):
+        super(BertAttention, self).__init__()
+        self.self = BertSelfAttention(config)
+        self.output = BertSelfOutput(config)
+
+    def forward(self, input_tensor, attention_mask):
+        self_output = self.self(input_tensor, attention_mask)
+        attention_output = self.output(self_output, input_tensor)
+        return attention_output
+
+
+class BertIntermediate(nn.Module):
+    def __init__(self, config):
+        super(BertIntermediate, self).__init__()
+        self.dense = nn.Linear(config.hidden_size, config.intermediate_size)
+        if isinstance(config.hidden_act, str):
+            self.intermediate_act_fn = ACT2FN[config.hidden_act]
+        else:
+            self.intermediate_act_fn = config.hidden_act
+
+    def forward(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
+        return hidden_states
+
+
+class BertOutput(nn.Module):
+    def __init__(self, config):
+        super(BertOutput, self).__init__()
+        self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.LayerNorm = BertLayerNorm(config.hidden_size, eps=1e-12)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states, input_tensor):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertLayer(nn.Module):
+    def __init__(self, config):
+        super(BertLayer, self).__init__()
+        self.attention = BertAttention(config)
+        self.intermediate = BertIntermediate(config)
+        self.output = BertOutput(config)
+
+    def forward(self, hidden_states, attention_mask):
+        attention_output = self.attention(hidden_states, attention_mask)
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        return layer_output
+
+
+class BertPooler(nn.Module):
+    def __init__(self, config):
+        super(BertPooler, self).__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.activation = nn.Tanh()
+
+    def forward(self, hidden_states):
+        # We "pool" the model by simply taking the hidden state corresponding
+        # to the first token.
+        first_token_tensor = hidden_states[:, 0]
+        pooled_output = self.dense(first_token_tensor)
+        pooled_output = self.activation(pooled_output)
+        return pooled_output
+
+
+class BertPredictionHeadTransform(nn.Module):
+    def __init__(self, config):
+        super(BertPredictionHeadTransform, self).__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        if isinstance(config.hidden_act, str):
+            self.transform_act_fn = ACT2FN[config.hidden_act]
+        else:
+            self.transform_act_fn = config.hidden_act
+        self.LayerNorm = BertLayerNorm(config.hidden_size, eps=1e-12)
+
+    def forward(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.transform_act_fn(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states)
+        return hidden_states
+
+
+class BertLMPredictionHead(nn.Module):
+    def __init__(self, config, bert_model_embedding_weights):
+        super(BertLMPredictionHead, self).__init__()
+        self.transform = BertPredictionHeadTransform(config)
+
+        # The output weights are the same as the input embeddings, but there is
+        # an output-only bias for each token.
+        self.decoder = nn.Linear(bert_model_embedding_weights.size(1),
+                                 bert_model_embedding_weights.size(0),
+                                 bias=False)
+        self.decoder.weight = bert_model_embedding_weights
+        self.bias = nn.Parameter(
+            torch.zeros(bert_model_embedding_weights.size(0)))
+
+    def forward(self, hidden_states):
+        hidden_states = self.transform(hidden_states)
+        hidden_states = self.decoder(hidden_states) + self.bias
+        return hidden_states
+
+
+class BertOnlyMLMHead(nn.Module):
+    def __init__(self, config, bert_model_embedding_weights):
+        super(BertOnlyMLMHead, self).__init__()
+        self.predictions = BertLMPredictionHead(config,
+                                                bert_model_embedding_weights)
+
+    def forward(self, sequence_output):
+        prediction_scores = self.predictions(sequence_output)
+        return prediction_scores

--- a/models/uniter/model.py
+++ b/models/uniter/model.py
@@ -1,0 +1,367 @@
+"""
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+
+Pytorch modules
+some classes are modified from HuggingFace
+(https://github.com/huggingface/transformers)
+"""
+import copy
+import json
+import logging
+from io import open
+
+import torch
+from torch import nn
+from torch.nn import LayerNorm as FusedLayerNorm
+
+from .layer import BertLayer, BertPooler
+
+
+logger = logging.getLogger(__name__)
+
+
+class UniterConfig(object):
+    """Configuration class to store the configuration of a `UniterModel`.
+    """
+    def __init__(self,
+                 vocab_size_or_config_json_file,
+                 hidden_size=768,
+                 num_hidden_layers=12,
+                 num_attention_heads=12,
+                 intermediate_size=3072,
+                 hidden_act="gelu",
+                 hidden_dropout_prob=0.1,
+                 attention_probs_dropout_prob=0.1,
+                 max_position_embeddings=512,
+                 type_vocab_size=2,
+                 initializer_range=0.02):
+        """Constructs UniterConfig.
+        Args:
+            vocab_size_or_config_json_file: Vocabulary size of `inputs_ids` in
+                `UniterModel`.
+            hidden_size: Size of the encoder layers and the pooler layer.
+            num_hidden_layers: Number of hidden layers in the Transformer
+                encoder.
+            num_attention_heads: Number of attention heads for each attention
+                layer in the Transformer encoder.
+            intermediate_size: The size of the "intermediate" (i.e.
+                feed-forward) layer in the Transformer encoder.
+            hidden_act: The non-linear activation function (function or string)
+                in the encoder and pooler. If string, "gelu", "relu" and
+                "swish" are supported.
+            hidden_dropout_prob: The dropout probabilitiy for all fully
+                connected layers in the embeddings, encoder, and pooler.
+            attention_probs_dropout_prob: The dropout ratio for the attention
+                probabilities.
+            max_position_embeddings: The maximum sequence length that this
+                model might ever be used with. Typically set this to something
+                large just in case (e.g., 512 or 1024 or 2048).
+            type_vocab_size: The vocabulary size of the `token_type_ids` passed
+                into `UniterModel`.
+            initializer_range: The sttdev of the truncated_normal_initializer
+                for initializing all weight matrices.
+        """
+        if isinstance(vocab_size_or_config_json_file, str):
+            with open(vocab_size_or_config_json_file,
+                      "r", encoding='utf-8') as reader:
+                json_config = json.loads(reader.read())
+            for key, value in json_config.items():
+                self.__dict__[key] = value
+        elif isinstance(vocab_size_or_config_json_file, int):
+            self.vocab_size = vocab_size_or_config_json_file
+            self.hidden_size = hidden_size
+            self.num_hidden_layers = num_hidden_layers
+            self.num_attention_heads = num_attention_heads
+            self.hidden_act = hidden_act
+            self.intermediate_size = intermediate_size
+            self.hidden_dropout_prob = hidden_dropout_prob
+            self.attention_probs_dropout_prob = attention_probs_dropout_prob
+            self.max_position_embeddings = max_position_embeddings
+            self.type_vocab_size = type_vocab_size
+            self.initializer_range = initializer_range
+        else:
+            raise ValueError("First argument must be either a vocabulary size "
+                             "(int) or the path to a pretrained model config "
+                             "file (str)")
+
+    @classmethod
+    def from_dict(cls, json_object):
+        """Constructs a `UniterConfig` from a
+           Python dictionary of parameters."""
+        config = UniterConfig(vocab_size_or_config_json_file=-1)
+        for key, value in json_object.items():
+            config.__dict__[key] = value
+        return config
+
+    @classmethod
+    def from_json_file(cls, json_file):
+        """Constructs a `UniterConfig` from a json file of parameters."""
+        with open(json_file, "r", encoding='utf-8') as reader:
+            text = reader.read()
+        return cls.from_dict(json.loads(text))
+
+    def __repr__(self):
+        return str(self.to_json_string())
+
+    def to_dict(self):
+        """Serializes this instance to a Python dictionary."""
+        output = copy.deepcopy(self.__dict__)
+        return output
+
+    def to_json_string(self):
+        """Serializes this instance to a JSON string."""
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+
+class UniterPreTrainedModel(nn.Module):
+    """ An abstract class to handle weights initialization and
+        a simple interface for dowloading and loading pretrained models.
+    """
+    def __init__(self, config, *inputs, **kwargs):
+        super().__init__()
+        if not isinstance(config, UniterConfig):
+            raise ValueError(
+                "Parameter config in `{}(config)` should be an instance of "
+                "class `UniterConfig`. To create a model from a Google "
+                "pretrained model use "
+                "`model = {}.from_pretrained(PRETRAINED_MODEL_NAME)`".format(
+                    self.__class__.__name__, self.__class__.__name__
+                ))
+        self.config = config
+
+    def init_weights(self, module):
+        """ Initialize the weights.
+        """
+        if isinstance(module, (nn.Linear, nn.Embedding)):
+            # Slightly different from the TF version which uses
+            # truncated_normal for initialization
+            # cf https://github.com/pytorch/pytorch/pull/5617
+            module.weight.data.normal_(mean=0.0,
+                                       std=self.config.initializer_range)
+        elif isinstance(module, FusedLayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+        if isinstance(module, nn.Linear) and module.bias is not None:
+            module.bias.data.zero_()
+
+    @classmethod
+    def from_pretrained(cls, config_file, state_dict, *inputs, **kwargs):
+        """
+        Instantiate a UniterPreTrainedModel from a pre-trained model file or a
+        pytorch state dict.
+        Params:
+            config_file: config json file
+            state_dict: an state dictionnary
+            *inputs, **kwargs: additional input for the specific Uniter class
+        """
+        # Load config
+        config = UniterConfig.from_json_file(config_file)
+        logger.info("Model config {}".format(config))
+        # Instantiate model.
+        model = cls(config, *inputs, **kwargs)
+        # Load from a PyTorch state_dict
+        old_keys = []
+        new_keys = []
+        for key in state_dict.keys():
+            new_key = None
+            if 'gamma' in key:
+                new_key = key.replace('gamma', 'weight')
+            if 'beta' in key:
+                new_key = key.replace('beta', 'bias')
+            if new_key:
+                old_keys.append(key)
+                new_keys.append(new_key)
+        for old_key, new_key in zip(old_keys, new_keys):
+            state_dict[new_key] = state_dict.pop(old_key)
+
+        missing_keys = []
+        unexpected_keys = []
+        error_msgs = []
+        # copy state_dict so _load_from_state_dict can modify it
+        metadata = getattr(state_dict, '_metadata', None)
+        state_dict = state_dict.copy()
+        if metadata is not None:
+            state_dict._metadata = metadata
+
+        def load(module, prefix=''):
+            local_metadata = ({} if metadata is None
+                              else metadata.get(prefix[:-1], {}))
+            module._load_from_state_dict(
+                state_dict, prefix, local_metadata, True, missing_keys,
+                unexpected_keys, error_msgs)
+            for name, child in module._modules.items():
+                if child is not None:
+                    load(child, prefix + name + '.')
+        start_prefix = ''
+        if not hasattr(model, 'bert') and any(s.startswith('bert.')
+                                              for s in state_dict.keys()):
+            start_prefix = 'bert.'
+        load(model, prefix=start_prefix)
+        if len(missing_keys) > 0:
+            logger.info("Weights of {} not initialized from "
+                        "pretrained model: {}".format(
+                            model.__class__.__name__, missing_keys))
+        if len(unexpected_keys) > 0:
+            logger.info("Weights from pretrained model not used in "
+                        "{}: {}".format(
+                            model.__class__.__name__, unexpected_keys))
+        if len(error_msgs) > 0:
+            raise RuntimeError('Error(s) in loading state_dict for '
+                               '{}:\n\t{}'.format(
+                                   model.__class__.__name__,
+                                   "\n\t".join(error_msgs)))
+        return model
+
+
+class UniterTextEmbeddings(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(config.vocab_size,
+                                            config.hidden_size, padding_idx=0)
+        self.position_embeddings = nn.Embedding(config.max_position_embeddings,
+                                                config.hidden_size)
+        self.token_type_embeddings = nn.Embedding(config.type_vocab_size,
+                                                  config.hidden_size)
+
+        # self.LayerNorm is not snake-cased to stick with TensorFlow model
+        # variable name and be able to load any TensorFlow checkpoint file
+        self.LayerNorm = FusedLayerNorm(config.hidden_size, eps=1e-12)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, input_ids, position_ids, token_type_ids=None):
+        if token_type_ids is None:
+            token_type_ids = torch.zeros_like(input_ids)
+
+        words_embeddings = self.word_embeddings(input_ids)
+        position_embeddings = self.position_embeddings(position_ids)
+        token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        embeddings = (words_embeddings
+                      + position_embeddings
+                      + token_type_embeddings)
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+
+class UniterImageEmbeddings(nn.Module):
+    def __init__(self, config, img_dim):
+        super().__init__()
+        self.img_linear = nn.Linear(img_dim, config.hidden_size)
+        self.img_layer_norm = FusedLayerNorm(config.hidden_size, eps=1e-12)
+        self.pos_layer_norm = FusedLayerNorm(config.hidden_size, eps=1e-12)
+        self.pos_linear = nn.Linear(7, config.hidden_size)
+        self.mask_embedding = nn.Embedding(2, img_dim, padding_idx=0)
+
+        # tf naming convention for layer norm
+        self.LayerNorm = FusedLayerNorm(config.hidden_size, eps=1e-12)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, img_feat, img_pos_feat, type_embeddings, img_masks=None):
+        if img_masks is not None:
+            self.mask_embedding.weight.data[0, :].fill_(0)
+            mask = self.mask_embedding(img_masks.long())
+            img_feat = img_feat + mask
+
+        transformed_im = self.img_layer_norm(self.img_linear(img_feat))
+        transformed_pos = self.pos_layer_norm(self.pos_linear(img_pos_feat))
+        embeddings = transformed_im + transformed_pos + type_embeddings
+        embeddings = self.LayerNorm(embeddings)
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+
+class UniterEncoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        layer = BertLayer(config)
+        self.layer = nn.ModuleList([copy.deepcopy(layer)
+                                    for _ in range(config.num_hidden_layers)])
+
+    def forward(self, input_, attention_mask,
+                output_all_encoded_layers=True):
+        all_encoder_layers = []
+        hidden_states = input_
+        for layer_module in self.layer:
+            hidden_states = layer_module(hidden_states, attention_mask)
+            if output_all_encoded_layers:
+                all_encoder_layers.append(hidden_states)
+        if not output_all_encoded_layers:
+            all_encoder_layers.append(hidden_states)
+        return all_encoder_layers
+
+
+class UniterModel(UniterPreTrainedModel):
+    """ Modification for Joint Vision-Language Encoding
+    """
+    def __init__(self, config, img_dim):
+        super().__init__(config)
+        self.embeddings = UniterTextEmbeddings(config)
+        self.img_embeddings = UniterImageEmbeddings(config, img_dim)
+        self.encoder = UniterEncoder(config)
+        self.pooler = BertPooler(config)
+        self.apply(self.init_weights)
+
+    def _compute_txt_embeddings(self, input_ids, position_ids,
+                                txt_type_ids=None):
+        output = self.embeddings(input_ids, position_ids, txt_type_ids)
+        return output
+
+    def _compute_img_embeddings(self, img_feat, img_pos_feat, img_masks=None,
+                                img_type_ids=None):
+        if img_type_ids is None:
+            img_type_ids = torch.ones_like(img_feat[:, :, 0].long())
+        img_type_embeddings = self.embeddings.token_type_embeddings(
+            img_type_ids)
+        output = self.img_embeddings(img_feat, img_pos_feat,
+                                     img_type_embeddings, img_masks)
+        return output
+
+    def _compute_img_txt_embeddings(self, input_ids, position_ids,
+                                    img_feat, img_pos_feat,
+                                    gather_index, img_masks=None,
+                                    txt_type_ids=None, img_type_ids=None):
+        txt_emb = self._compute_txt_embeddings(
+            input_ids, position_ids, txt_type_ids)
+        img_emb = self._compute_img_embeddings(
+            img_feat, img_pos_feat, img_masks, img_type_ids)
+        # align back to most compact input
+        gather_index = gather_index.unsqueeze(-1).expand(
+            -1, -1, self.config.hidden_size)
+        embedding_output = torch.gather(torch.cat([txt_emb, img_emb], dim=1),
+                                        dim=1, index=gather_index)
+        return embedding_output
+
+    def forward(self, input_ids, position_ids,
+                img_feat, img_pos_feat,
+                attention_mask, gather_index=None, img_masks=None,
+                output_all_encoded_layers=True,
+                txt_type_ids=None, img_type_ids=None):
+        # compute self-attention mask
+        extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_attention_mask = extended_attention_mask.to(
+            dtype=next(self.parameters()).dtype)  # fp16 compatibility
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
+        # embedding layer
+        if input_ids is None:
+            # image only
+            embedding_output = self._compute_img_embeddings(
+                img_feat, img_pos_feat, img_masks, img_type_ids)
+        elif img_feat is None:
+            # text only
+            embedding_output = self._compute_txt_embeddings(
+                input_ids, position_ids, txt_type_ids)
+        else:
+            embedding_output = self._compute_img_txt_embeddings(
+                input_ids, position_ids,
+                img_feat, img_pos_feat,
+                gather_index, img_masks, txt_type_ids, img_type_ids)
+
+        encoded_layers = self.encoder(
+            embedding_output, extended_attention_mask,
+            output_all_encoded_layers=output_all_encoded_layers)
+        if not output_all_encoded_layers:
+            encoded_layers = encoded_layers[-1]
+        return encoded_layers

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,6 +6,8 @@ from metrics.clip_score import ClipScoreMetric
 from metrics.polos import PolosMetric
 from metrics.standard import StandardMetric
 from metrics.bert_score import BertScoreBasic, BertScoreImproved
+from metrics.umic_score import UmicScore
+
 
 def collate_fn(batch):
     if isinstance(batch, tuple) and isinstance(batch[0], list):
@@ -71,5 +73,7 @@ def get_metric(name, **kwargs):
         return BertScoreBasic("en")
     elif name == "bert-score++":
         return BertScoreImproved("en")
+    elif name == "umic-score":
+        return UmicScore()
     else:
         raise ValueError(f"Unknown metric: {name}")


### PR DESCRIPTION
Hi there,

This PR is for [UMIC score](https://github.com/hwanheelee1993/UMIC/). The difference between this PR and the UMIC author are:

1. The UMIC author precompute the image feature of the popular benchmark dataset, but they did not provide the code to compute visual feature, and my work did it with Detectron2, it is the class ImageFeatureEmbedder. That means this version can be applied for new datasets as well.
2. Their work seems to use the `faster_rcnn_R_101_C4_3x.yaml` which produce the visual feature with size of (B, N, 2048) and my work use `faster_rcnn_R_101_FPN_3x.yaml` which produce the visual feature with size of (B, N, 1024). But the idea is the same, both methods want to represent image with regional image feature. Potential for future work to replicate their work with `faster_rcnn_R_101_C4_3x.yaml` config.

the files `models/uniter/model.py` and `models/uniter/layer.py` is originated from [UNITER](https://github.com/ChenRocks/UNITER/) repository. I only replace their choice of `FusedLayerNorm` from apex because it was kinda unreasonable, nobody wants to install the whole apex for just a norm layer which can easily imported from torch `LayerNorm`

Lastly, the instruction on how to install detectron2 is already included in the umic_score.py file, I didnt modify your `requirements.txt` to include my detectron2 version because it was a quite tricky process to get it running on my environment. so I recommend to install it separately.

Cheers,

Hien Bui